### PR TITLE
Fix speech-to-text type assignment error

### DIFF
--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -50,6 +50,7 @@ export interface WebviewMessage {
 		| "deleteMessage"
 		| "terminalOutputLineLimit"
 		| "mcpEnabled"
+		| "speechToText"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse


### PR DESCRIPTION
Add "speechToText" to the `WebviewMessage` type definition.

* Modify `src/shared/WebviewMessage.ts` to include "speechToText" in the `WebviewMessage` type definition.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Vic563/Roo-Cline/pull/2?shareId=763a314b-c3a4-48b5-a8d8-b946ef035e8e).